### PR TITLE
features: adding a simple HTTP router

### DIFF
--- a/httpRouter/router.go
+++ b/httpRouter/router.go
@@ -1,0 +1,31 @@
+package httpRouter
+
+import "net/http"
+
+type Router struct{}
+
+func CreateNewRouter() *Router {
+	router := &Router{}
+
+	return router
+}
+
+func (r *Router) Run() {
+	http.ListenAndServe(":8080", nil)
+}
+
+func (r *Router) GET(path string, handler http.HandlerFunc) {
+	http.HandleFunc(path, handler)
+}
+
+func (r *Router) POST(path string, handler http.HandlerFunc) {
+	http.HandleFunc(path, handler)
+}
+
+func (r *Router) PUT(path string, handler http.HandlerFunc) {
+	http.HandleFunc(path, handler)
+}
+
+func (r *Router) DELETE(path string, handler http.HandlerFunc) {
+	http.HandleFunc(path, handler)
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,17 @@
 package main
 
-import "net/http"
+import (
+	"contacts-0/httpRouter"
+	"fmt"
+	"net/http"
+)
 
 func main() {
-	http.ListenAndServe(":8080", nil)
+	router := httpRouter.CreateNewRouter()
+
+	router.GET("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Working as expected!")
+	})
+
+	router.Run()
 }


### PR DESCRIPTION
Adding a simple HTTP router

The router can be used to map HTTP requests to handler functions. The following methods are provided:

`CreateNewRouter():` Creates a new router.
`Run():` Starts the router listening on port 8080.
`GET(path string, handler http.HandlerFunc):` Maps HTTP GET requests to the specified handler function.
`POST(path string, handler http.HandlerFunc):` Maps HTTP POST requests to the specified handler function.
`PUT(path string, handler http.HandlerFunc):` Maps HTTP PUT requests to the specified handler function.
`DELETE(path string, handler http.HandlerFunc):` Maps HTTP DELETE requests to the specified handler function.
